### PR TITLE
Drop java 8 from build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8, 11, 17]
+        java: [11, 17]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
The readme states "Requires JDK 11+" (https://github.com/lightbend-labs/jardiff/pull/114), probably because the project is using logback 1.4.x?