### PR TITLE
Set JDK to 1.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [11, 17]
+        java: [8, 11, 17]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,5 @@
+updates.ignore = [
+  // These updates are ignored to ensure JDK 1.8 support
+  { groupId = "org.eclipse.jgit", artifactId = "org.eclipse.jgit" },
+  { groupId = "ch.qos.logback", artifactId = "logback-classic"}
+]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A tool for generating bytecode diffs
 
-Requires JDK 11+
+Requires JDK 8+
 
 ## About
 

--- a/build.sbt
+++ b/build.sbt
@@ -34,10 +34,10 @@ lazy val core = (
       "org.ow2.asm" % "asm" % AsmVersion,
       "org.ow2.asm" % "asm-util" % AsmVersion,
       "org.scala-lang" % "scalap" % System.getProperty("scalap.version", scalaVersion.value),
-      "org.eclipse.jgit" % "org.eclipse.jgit" % "6.7.0.202309050840-r",
+      "org.eclipse.jgit" % "org.eclipse.jgit" % "5.13.2.202306221912-r",
       "org.slf4j" % "slf4j-api" % "2.0.9",
       "org.slf4j" % "log4j-over-slf4j" % "2.0.9", // for any java classes looking for this
-      "ch.qos.logback" % "logback-classic" % "1.4.11",
+      "ch.qos.logback" % "logback-classic" % "1.3.11",
       "org.scalatest" %% "scalatest" % "3.2.17" % Test,
     ),
     name := buildName + "-core",

--- a/core/src/test/scala/JDK8SmokeTest.scala
+++ b/core/src/test/scala/JDK8SmokeTest.scala
@@ -1,0 +1,16 @@
+import org.eclipse.jgit.api.Git
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.slf4j.LoggerFactory
+
+final class JDK8SmokeTest extends AnyFlatSpec with Matchers {
+  behavior of "Testing dependencies are compiled with JDK 1.8"
+
+  it should "make sure slf4j/logback works" in {
+    LoggerFactory.getLogger(getClass.getName)
+  }
+
+  it should "make sure JGit works" in {
+    Git.init
+  }
+}


### PR DESCRIPTION
The intention of this PR is to test if this project can compile with JDK 8. The reasons for this are

1. At least with Pekko where we use this project to validate releases (i.e. we check if there is a bytecode difference between staging and locally built artifacts) and since Pekko is built with JDK 1.8 we constantly have to switch JDK's when testing with jardiff

2. Given https://github.com/lightbend-labs/jardiff/pull/52 it makes sense to target JDK 1.8 since almost all sbt plugins target 1.8 (given that its built with Scala 2.12).