### PR TITLE
remove redundant publishing stuff in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,9 +49,6 @@ lazy val root = (
   settings(
     name := buildName,
     publish / skip := true,
-    publishArtifact := false,
-    publish := {},
-    publishLocal := {}
   )
 )
 
@@ -85,7 +82,4 @@ lazy val cli = project.
     },
     // cli is not meant to be published
     publish / skip := true,
-    publishArtifact := false,
-    publish := {},
-    publishLocal := {}
   ).dependsOn(core)


### PR DESCRIPTION
you sometimes see this redundant stuff get cargo culted because it used to be necessary in old sbt versions, but these days `publish / skip` is sufficient

review by @mdedetrich 