### PR TITLE
Add support for Scala 2.13 to core

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,8 @@
 val buildName = "jardiff"
 
+val scala212Version = "2.12.18"
+val scala213Version = "2.13.12"
+
 inThisBuild(Seq[Setting[_]](
   organization := "com.lightbend",
   scalaVersion := "2.13.12",
@@ -51,7 +54,9 @@ lazy val root = (
     publish / skip := true,
     publishArtifact := false,
     publish := {},
-    publishLocal := {}
+    publishLocal := {},
+    // See https://github.com/sbt/sbt/issues/4262#issuecomment-405607763
+    crossScalaVersions := Seq.empty
   )
 )
 
@@ -69,7 +74,9 @@ lazy val core = project.
       "ch.qos.logback" % "logback-classic" % "1.3.11",
       "org.scalatest" %% "scalatest" % "3.2.17" % Test,
     ),
-    name := buildName + "-core"
+    name := buildName + "-core",
+    crossScalaVersions := Seq(scala212Version, scala213Version),
+    scalaVersion := scala212Version
   )
 
 lazy val cli = project.
@@ -83,6 +90,11 @@ lazy val cli = project.
       case x if x.endsWith("module-info.class") => MergeStrategy.discard
       case x => (assembly / assemblyMergeStrategy).value(x)
     },
+    // Having Scala 2.13 here in crossScalaVersions is redundant but due to how
+    // sbt-github-actions generates the sbt test command (i.e. sbt '++ 2.13.12' test),
+    // sbt's update task cannot handle projects with different crossScalaVersions well
+    crossScalaVersions := Seq(scala212Version, scala213Version),
+    scalaVersion := scala212Version,
     // cli is not meant to be published
     publish / skip := true,
     publishArtifact := false,

--- a/cli/src/main/scala/scala/tools/jardiff/Main.scala
+++ b/cli/src/main/scala/scala/tools/jardiff/Main.scala
@@ -4,6 +4,8 @@
 
 package scala.tools.jardiff
 
+import JDKCollectionConvertersCompat.Converters._
+
 import java.io.{ByteArrayOutputStream, File, PrintWriter}
 import java.nio.file._
 
@@ -11,7 +13,6 @@ import org.apache.commons.cli
 import org.apache.commons.cli.{CommandLine, DefaultParser, HelpFormatter, Options}
 import org.eclipse.jgit.util.io.NullOutputStream
 
-import scala.jdk.CollectionConverters._
 import scala.util.Try
 import scala.util.control.NonFatal
 

--- a/core/src/main/scala/scala/tools/jardiff/AsmTextifyRenderer.scala
+++ b/core/src/main/scala/scala/tools/jardiff/AsmTextifyRenderer.scala
@@ -4,10 +4,11 @@
 
 package scala.tools.jardiff
 
+import JDKCollectionConvertersCompat.Converters._
+
 import java.io.PrintWriter
 import java.nio.file.{Files, Path}
 
-import scala.jdk.CollectionConverters._
 import org.objectweb.asm.{ClassReader, Opcodes}
 import org.objectweb.asm.tree.{ClassNode, FieldNode, InnerClassNode, MethodNode}
 import org.objectweb.asm.util.TraceClassVisitor

--- a/core/src/main/scala/scala/tools/jardiff/JDKCollectionConvertersCompat.scala
+++ b/core/src/main/scala/scala/tools/jardiff/JDKCollectionConvertersCompat.scala
@@ -1,0 +1,31 @@
+package scala.tools.jardiff
+
+import scala.annotation.nowarn
+
+/** Magic to get cross-compiling access to `scala.jdk.CollectionConverters`
+ *  with a fallback on `scala.collection.JavaConverters`, without deprecation
+ *  warning in any Scala version.
+ *
+ *  @see https://github.com/scala/scala-collection-compat/issues/208
+ */
+@nowarn("msg=Unused import")
+private[jardiff] object JDKCollectionConvertersCompat {
+  object Scope1 {
+    object jdk {
+      type CollectionConverters = Int
+    }
+  }
+  import Scope1._
+
+  object Scope2 {
+    import scala.collection.{JavaConverters => CollectionConverters}
+
+    object Inner {
+      import scala._
+      import jdk.CollectionConverters
+      val Converters = CollectionConverters
+    }
+  }
+
+  val Converters = Scope2.Inner.Converters
+}

--- a/core/src/main/scala/scala/tools/jardiff/JarDiff.scala
+++ b/core/src/main/scala/scala/tools/jardiff/JarDiff.scala
@@ -4,6 +4,8 @@
 
 package scala.tools.jardiff
 
+import JDKCollectionConvertersCompat.Converters._
+
 import java.io.{File, OutputStream}
 import java.nio.file._
 import java.nio.file.attribute.BasicFileAttributes
@@ -14,7 +16,6 @@ import org.eclipse.jgit.lib.RepositoryCache
 import org.eclipse.jgit.revwalk.RevCommit
 
 import scala.tools.jardiff.JGitUtil._
-import scala.jdk.CollectionConverters._
 
 final class JarDiff(files: List[List[Path]], config: JarDiff.Config, renderers: String => List[FileRenderer]) {
   private val targetBase = config.gitRepo.getOrElse(Files.createTempDirectory("jardiff-"))


### PR DESCRIPTION
Works as expected, i.e.

```
[IJ]+publishLocal
[info] Setting Scala version to 2.12.18 on 2 projects.
[info] Excluded 1 projects, run ++ 2.12.18 -v for more details.
[info] Reapplying settings...
[info] set current project to jardiff (in build file:/Users/mdedetrich/github/jardiff/)
[info] Wrote /Users/mdedetrich/github/jardiff/core/target/scala-2.12/jardiff-core_2.12-1.8.0+13-5212ff2a+20231103-0844-SNAPSHOT.pom
[info] Main Scala API documentation to /Users/mdedetrich/github/jardiff/core/target/scala-2.12/api...
model contains 14 documentable templates
[info] Main Scala API documentation successful.
[info] :: delivering :: com.lightbend#jardiff-core_2.12;1.8.0+13-5212ff2a+20231103-0844-SNAPSHOT :: 1.8.0+13-5212ff2a+20231103-0844-SNAPSHOT :: integration :: Fri Nov 03 08:44:07 CET 2023
[info] 	delivering ivy file to /Users/mdedetrich/github/jardiff/core/target/scala-2.12/ivy-1.8.0+13-5212ff2a+20231103-0844-SNAPSHOT.xml
[info] 	published jardiff-core_2.12 to /Users/mdedetrich/.ivy2/local/com.lightbend/jardiff-core_2.12/1.8.0+13-5212ff2a+20231103-0844-SNAPSHOT/poms/jardiff-core_2.12.pom
[info] 	published jardiff-core_2.12 to /Users/mdedetrich/.ivy2/local/com.lightbend/jardiff-core_2.12/1.8.0+13-5212ff2a+20231103-0844-SNAPSHOT/jars/jardiff-core_2.12.jar
[info] 	published jardiff-core_2.12 to /Users/mdedetrich/.ivy2/local/com.lightbend/jardiff-core_2.12/1.8.0+13-5212ff2a+20231103-0844-SNAPSHOT/srcs/jardiff-core_2.12-sources.jar
[info] 	published jardiff-core_2.12 to /Users/mdedetrich/.ivy2/local/com.lightbend/jardiff-core_2.12/1.8.0+13-5212ff2a+20231103-0844-SNAPSHOT/docs/jardiff-core_2.12-javadoc.jar
[info] 	published ivy to /Users/mdedetrich/.ivy2/local/com.lightbend/jardiff-core_2.12/1.8.0+13-5212ff2a+20231103-0844-SNAPSHOT/ivys/ivy.xml
[success] Total time: 4 s, completed Nov 3, 2023 8:44:07 AM
[info] Setting Scala version to 2.13.12 on 1 projects.
[info] Excluded 2 projects, run ++ 2.13.12 -v for more details.
[info] Reapplying settings...
[info] set current project to jardiff (in build file:/Users/mdedetrich/github/jardiff/)
[info] Wrote /Users/mdedetrich/github/jardiff/core/target/scala-2.13/jardiff-core_2.13-1.8.0+13-5212ff2a+20231103-0844-SNAPSHOT.pom
[info] Main Scala API documentation to /Users/mdedetrich/github/jardiff/core/target/scala-2.13/api...
[info] Main Scala API documentation successful.
[info] :: delivering :: com.lightbend#jardiff-core_2.13;1.8.0+13-5212ff2a+20231103-0844-SNAPSHOT :: 1.8.0+13-5212ff2a+20231103-0844-SNAPSHOT :: integration :: Fri Nov 03 08:44:11 CET 2023
[info] 	delivering ivy file to /Users/mdedetrich/github/jardiff/core/target/scala-2.13/ivy-1.8.0+13-5212ff2a+20231103-0844-SNAPSHOT.xml
[info] 	published jardiff-core_2.13 to /Users/mdedetrich/.ivy2/local/com.lightbend/jardiff-core_2.13/1.8.0+13-5212ff2a+20231103-0844-SNAPSHOT/poms/jardiff-core_2.13.pom
[info] 	published jardiff-core_2.13 to /Users/mdedetrich/.ivy2/local/com.lightbend/jardiff-core_2.13/1.8.0+13-5212ff2a+20231103-0844-SNAPSHOT/jars/jardiff-core_2.13.jar
[info] 	published jardiff-core_2.13 to /Users/mdedetrich/.ivy2/local/com.lightbend/jardiff-core_2.13/1.8.0+13-5212ff2a+20231103-0844-SNAPSHOT/srcs/jardiff-core_2.13-sources.jar
[info] 	published jardiff-core_2.13 to /Users/mdedetrich/.ivy2/local/com.lightbend/jardiff-core_2.13/1.8.0+13-5212ff2a+20231103-0844-SNAPSHOT/docs/jardiff-core_2.13-javadoc.jar
[info] 	published ivy to /Users/mdedetrich/.ivy2/local/com.lightbend/jardiff-core_2.13/1.8.0+13-5212ff2a+20231103-0844-SNAPSHOT/ivys/ivy.xml
[success] Total time: 3 s, completed Nov 3, 2023 8:44:11 AM
[info] Reapplying settings...
[info] set current project to jardiff (in build file:/Users/mdedetrich/github/jardiff/)
[IJ]
```

I wanted to also add support for Scala 3 but scalap is not published for Scala 3 (probably intentional, I guess @retronym can add more context here, apparently scalap can be compiled for Scala 3 https://www.jannikarndt.de/blog/2021/03/using_scalap_javap_and_the_scala_compiler/ ???).

The CLI is set to a single Scala version (in this case 2.12) but the decision is arbitrary as it can be anything really.