### PR TITLE
remove unnecessary build stuff

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,9 +41,6 @@ inThisBuild(Seq[Setting[_]](
   headerLicense := Some(HeaderLicense.Custom("Copyright (C) Lightbend Inc. <https://www.lightbend.com>")),
 ))
 
-ThisBuild / publishMavenStyle      := true
-ThisBuild / publishTo              := sonatypePublishToBundle.value
-ThisBuild / test / publishArtifact := false
 ThisBuild / pomIncludeRepository   := (_ => false)
 
 lazy val root = (


### PR DESCRIPTION
at least, I don't think any of this stuff is recommended or necessary under sbt-ci-release?

@mdedetrich the `pomIncludeRepository`, I'm least sure about it. do you know what that's for?

note that before this change (but after I added the secrets to the repo) we were seeing successful snapshot publishing at e.g. https://github.com/lightbend-labs/jardiff/actions/runs/6746086611/job/18339309410

so if we merge this, we should double check after that it's still working